### PR TITLE
feat: enable bypassing persisted operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,10 +110,12 @@ persistedOperations?: { [hash: string]: string };
 persistedOperationsGetter?: PersistedOperationGetter;
 
 /**
- * In development it's common to want to send arbitrary queries from GraphiQL
- * whilst also enforcing Persisted Operations from the application. You should
- * use this function if you want unpersisted operation to be allowed in some
- * context (e.g in development).
+ * There are situations where you may want to allow arbitrary operations
+ * (for example using GraphiQL in development, or allowing an admin to
+ * make arbitrary requests in production) whilst enforcing Persisted
+ * Operations for the application and non-admin users. This function
+ * allows you to determine under which circumstances persisted operations
+ * may be bypassed.
  *
  * @example
  *

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ const postGraphileMiddleware = postgraphile(databaseUrl, "app_public", {
 
 This plugin adds the following options to the PostGraphile library options:
 
-````ts
+```ts
 /**
  * This function will be passed a GraphQL request object (normally `{query:
  * string, variables?: any, operationName?: string, extensions?: any}`, but
@@ -117,6 +117,8 @@ persistedOperationsGetter?: PersistedOperationGetter;
  * allows you to determine under which circumstances persisted operations
  * may be bypassed.
  *
+ * IMPORTANT: this function must not throw!
+ *
  * @example
  *
  * ```
@@ -128,7 +130,7 @@ persistedOperationsGetter?: PersistedOperationGetter;
  * ```
  */ 
  allowUnpersistedOperation?: boolean | ((request: IncomingMessage, payload: any): boolean);
-````
+```
 
 All these options are optional; but you should specify exactly one of
 `persistedOperationsDirectory`, `persistedOperations` or

--- a/README.md
+++ b/README.md
@@ -126,8 +126,8 @@ persistedOperationsGetter?: PersistedOperationGetter;
  *   }
  * });
  * ```
- */
-allowUnpersistedOperation?(request: any): boolean;
+ */ 
+ allowUnpersistedOperation?(request?: IncomingMessage, payload?: any): boolean;
 ```
 
 All these options are optional; but you should specify exactly one of

--- a/README.md
+++ b/README.md
@@ -114,12 +114,16 @@ persistedOperationsGetter?: PersistedOperationGetter;
  * whilst also enforcing Persisted Operations from the application. You should
  * use this function if you want unpersisted operation to be allowed in some
  * context (e.g in development).
+ *
  * @example
+ *
+ * ```
  * app.use(postgraphile(DATABASE_URL, SCHEMAS, {
  *   allowUnpersistedOperation(req) {
- *     return process.env.NODE_ENV === "development" && req.headers.referer.endsWith("/graphiql");
+ *     return process.env.NODE_ENV === "development" && req.headers.referer?.endsWith("/graphiql");
  *   }
  * });
+ * ```
  */
 allowUnpersistedOperation?(request: any): boolean;
 ```

--- a/README.md
+++ b/README.md
@@ -108,6 +108,20 @@ persistedOperations?: { [hash: string]: string };
  * stores (e.g. S3).
  */
 persistedOperationsGetter?: PersistedOperationGetter;
+
+/**
+ * In development it's common to want to send arbitrary queries from GraphiQL
+ * whilst also enforcing Persisted Operations from the application. You should
+ * use this function if you want unpersisted operation to be allowed in some
+ * context (e.g in development).
+ * @example
+ * app.use(postgraphile(DATABASE_URL, SCHEMAS, {
+ *   allowUnpersistedOperation(req) {
+ *     return process.env.NODE_ENV === "development" && req.headers.referer.endsWith("/graphiql");
+ *   }
+ * });
+ */
+allowUnpersistedOperation?(request: any): boolean;
 ```
 
 All these options are optional; but you should specify exactly one of

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ const postGraphileMiddleware = postgraphile(databaseUrl, "app_public", {
 
 This plugin adds the following options to the PostGraphile library options:
 
-```ts
+````ts
 /**
  * This function will be passed a GraphQL request object (normally `{query:
  * string, variables?: any, operationName?: string, extensions?: any}`, but
@@ -127,8 +127,8 @@ persistedOperationsGetter?: PersistedOperationGetter;
  * });
  * ```
  */ 
- allowUnpersistedOperation?(request: IncomingMessage, payload: any): boolean;
-```
+ allowUnpersistedOperation?: boolean | ((request: IncomingMessage, payload: any): boolean);
+````
 
 All these options are optional; but you should specify exactly one of
 `persistedOperationsDirectory`, `persistedOperations` or

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ const postGraphileMiddleware = postgraphile(databaseUrl, "app_public", {
 
 This plugin adds the following options to the PostGraphile library options:
 
-```ts
+````ts
 /**
  * This function will be passed a GraphQL request object (normally `{query:
  * string, variables?: any, operationName?: string, extensions?: any}`, but
@@ -128,9 +128,9 @@ persistedOperationsGetter?: PersistedOperationGetter;
  *   }
  * });
  * ```
- */ 
- allowUnpersistedOperation?: boolean | ((request: IncomingMessage, payload: any): boolean);
-```
+ */
+ allowUnpersistedOperation?: boolean | ((request: IncomingMessage, payload: RequestPayload): boolean);
+````
 
 All these options are optional; but you should specify exactly one of
 `persistedOperationsDirectory`, `persistedOperations` or

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ persistedOperationsGetter?: PersistedOperationGetter;
  * });
  * ```
  */ 
- allowUnpersistedOperation?(request?: IncomingMessage, payload?: any): boolean;
+ allowUnpersistedOperation?(request: IncomingMessage, payload: any): boolean;
 ```
 
 All these options are optional; but you should specify exactly one of

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # Release notes
 
+### Pending
+
+- Added `allowUnpersistedOperation` option, allowing arbitrary operations to be issued under controlled circumstances
+
 ### v0.0.3
 
 - Relay compiler should now work with no additional config
@@ -11,7 +15,3 @@
 ### v0.0.1
 
 - Initial release
-
-### Pending
-
-- Added `allowUnpersistedOperation` option, allowing arbitrary operations to be issued under controlled circumstances

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,3 +11,7 @@
 ### v0.0.1
 
 - Initial release
+
+### Pending
+
+- Added allowUnpersistedOperation to postgraphile option. It allows to bypass security (e.g in development environment)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,4 +14,4 @@
 
 ### Pending
 
-- Added allowUnpersistedOperation to postgraphile option. It allows to bypass security (e.g in development environment)
+- Added `allowUnpersistedOperation` option, allowing arbitrary operations to be issued under controlled circumstances

--- a/src/index.ts
+++ b/src/index.ts
@@ -226,10 +226,8 @@ function persistedOperationFromPayload(
     const hashFromPayload = options.hashFromPayload || defaultHashFromPayload;
     const hash = hashFromPayload(payload);
     if (typeof hash !== "string") {
-      if (allowUnpersistedOperation) {
-        if (typeof payload?.query === "string") {
-          return payload.query;
-        }
+      if (allowUnpersistedOperation && typeof payload?.query === "string") {
+        return payload.query;
       }
 
       throw new Error(

--- a/src/index.ts
+++ b/src/index.ts
@@ -225,7 +225,7 @@ function persistedOperationFromPayload(
       const allowUnpersistedOperations =
         options.allowUnpersistedOperation || (() => false);
 
-      if (allowUnpersistedOperations(options)) {
+      if (allowUnpersistedOperations(payload)) {
         const query = queryFromPayload(payload);
         if (typeof query === "string") {
           return query;

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,6 +59,8 @@ declare module "postgraphile" {
      * allows you to determine under which circumstances persisted operations
      * may be bypassed.
      *
+     * IMPORTANT: this function must not throw!
+     *
      * @example
      *
      * ```
@@ -211,13 +213,11 @@ function getterFromOptions(options: PostGraphileOptions) {
 }
 
 function allowUnpersistedOperationsFromOptions(options: PostGraphileOptions, request: IncomingMessage, payload: any): boolean {
-  if (options.allowUnpersistedOperation === undefined || options.allowUnpersistedOperation === null) {
-    return false;
+  const { allowUnpersistedOperation } = options;
+  if (typeof allowUnpersistedOperation === 'function') {
+    return allowUnpersistedOperation(request, payload);
   }
-  if (typeof options.allowUnpersistedOperation === 'boolean') {
-    return options.allowUnpersistedOperation;
-  }
-  return options.allowUnpersistedOperation(request, payload);
+  return !!allowUnpersistedOperation;
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -245,7 +245,7 @@ interface RequestPayload {
   operationName?: string;
 }
 
-function allowUnpersistedOperationsFromOptions(
+function shouldAllowUnpersistedOperation(
   options: PostGraphileOptions,
   request: IncomingMessage,
   payload: RequestPayload
@@ -333,7 +333,7 @@ const PersistedQueriesPlugin: PostGraphilePlugin = {
       params.query = persistedOperationFromPayload(
         params,
         options,
-        allowUnpersistedOperationsFromOptions(options, req, params)
+        shouldAllowUnpersistedOperation(options, req, params)
       ) as string;
       return params;
     });
@@ -347,7 +347,7 @@ const PersistedQueriesPlugin: PostGraphilePlugin = {
     params.query = persistedOperationFromPayload(
       message.payload,
       options,
-      allowUnpersistedOperationsFromOptions(options, req, params)
+      shouldAllowUnpersistedOperation(options, req, params)
     ) as string;
     return params;
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -297,6 +297,10 @@ const PersistedQueriesPlugin: PostGraphilePlugin = {
       "--persisted-operations-directory <fullpath>",
       "[@graphile/persisted-operations] The path to the directory in which we'd find the persisted query files (each named <hash>.graphql)"
     );
+    addFlag(
+      "--allow-unpersisted-operations",
+      "[@graphile/persisted-operations] Allow clients to send regular GraphQL queries (not just persisted operations); it's better to control this on a per-request basis in library mode instead."
+    );
 
     // The ouput from one plugin is fed as the input into the next, so we must
     // remember to return the input.
@@ -305,13 +309,17 @@ const PersistedQueriesPlugin: PostGraphilePlugin = {
 
   ["cli:library:options"](options, { config, cliOptions }) {
     // Take the CLI options and add them as PostGraphile options.
-    const { persistedOperationsDirectory = undefined } = {
+    const {
+      persistedOperationsDirectory = undefined,
+      allowUnpersistedOperations = undefined,
+    } = {
       ...config["options"],
       ...cliOptions,
     };
     return {
       ...options,
       persistedOperationsDirectory,
+      allowUnpersistedOperation: allowUnpersistedOperations,
     };
   },
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,8 +70,8 @@ declare module "postgraphile" {
      * ```
      */
     allowUnpersistedOperation?(
-      request?: IncomingMessage,
-      payload?: any
+      request: IncomingMessage,
+      payload: any
     ): boolean;
   }
 }


### PR DESCRIPTION
## Description

This PR is a feature originally discussed in #2 

It allows for an additional postgraphile option `allowUnpersistedQueries (req: any): boolean` for bypassing persisted queries (you usually want that in development environment).

## Performance impact

This feature adds code that is executed if the query hash is not found. It does the following :
- Get allowUnpersistedQueries
- If allowUnpersistedQueries returns true, it get the query from payload and returns it

## Security impact

Maybe we should add a warning for developpers to inform that an unpersisted query has been sent ?

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [x] I have detailed the new feature in the relevant documentation.
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [x] If this is a breaking change I've explained why.
